### PR TITLE
Remove sveltekit dependency in api and fix lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
 	},
 	"peerDependencies": {
 		"@fortawesome/free-solid-svg-icons": "^6.2.1",
-		"@sveltejs/kit": "1.0.0-next.551",
 		"svelte": "^3.53.1",
 		"tailwindcss": "^3.2.4"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "1.0.0-next.88",
+		"@sveltejs/kit": "1.0.0-next.551",
 		"@testing-library/jest-dom": "5.16.5",
 		"@testing-library/svelte": "3.2.2",
 		"autoprefixer": "10.4.13",

--- a/src/lib/layout/nav-item.svelte
+++ b/src/lib/layout/nav-item.svelte
@@ -1,16 +1,12 @@
 <script>
-	import { page } from '$app/stores'
-
 	import Icon from '$lib/icon.svelte'
 
 	export let icon
 	export let label
 	export let route
+	export let pathname
 
-	$: textClass =
-		$page && $page.url && $page.url.pathname === route
-			? 'text-white'
-			: 'text-gray-400'
+	$: textClass = pathname === route ? 'text-white' : 'text-gray-400'
 </script>
 
 <div class="px-2 py-1 sm:flex sm:p-0">

--- a/src/lib/layout/theme-mode-toggle.svelte
+++ b/src/lib/layout/theme-mode-toggle.svelte
@@ -1,8 +1,9 @@
 <script>
-	import { browser } from '$app/environment'
 	import { faMoon, faSun } from '@fortawesome/free-solid-svg-icons'
 
 	import Icon from '$lib/icon.svelte'
+
+	export let browser = false
 
 	let darkMode = false
 	let focused = false

--- a/src/lib/modal.svelte
+++ b/src/lib/modal.svelte
@@ -23,6 +23,7 @@
 	transition:fade
 	class="fixed top-0 left-0 w-full h-full z-100 bg-gray-200 dark:bg-gray-700 opacity-60"
 	on:click="{closeModal}"
+	on:keydown="{closeModal}"
 ></div>
 
 <div

--- a/src/lib/page/binary-record.svelte
+++ b/src/lib/page/binary-record.svelte
@@ -11,6 +11,7 @@
 	<div
 		class="cursor-pointer text-primary-500 inline-block"
 		on:click|preventDefault="{openFile(field, fieldContentType)}"
+		on:keyup="{e => e.key === 'Enter' && openFile(field, fieldContentType)}"
 	>
 		{#if fieldType === 'image'}
 			<img


### PR DESCRIPTION
- Remove `SvelteKit` specific API dependency from library code and allow those as input on affected components
- Fix lint warnings